### PR TITLE
NEW: Add optional phpstan execution to PHPCS_TEST

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -120,10 +120,11 @@ script:
   # BEHAT
   - if [[ $BEHAT_TEST ]]; then vendor/bin/behat $BEHAT_SUITE; fi
 
-  # PHPCS
+  # PHPCS and PHPSTAND
   - if [[ $PHPCS_TEST && -f phpcs.xml.dist ]]; then vendor/bin/phpcs; fi
+  - if [[ $PHPCS_TEST && -f phpstan.neon.dist ]]; then vendor/bin/phpstan analyse; fi
 
-  # NPM
+# NPM
   - if [[ $NPM_TEST ]]; then git diff-files --quiet -w --relative=client; fi
   - if [[ $NPM_TEST ]]; then git diff --name-status --relative=client; fi
   - if [[ $NPM_TEST ]]; then yarn run test; fi


### PR DESCRIPTION
PHPStan is a static analyser that may be of use to some repositories. Notably, I've got a small, passing PHPStan level 1 PR to submit to framework.

This will include a phpstan call in the PHPCS_TEST build, if phpstan.neon.dist exists.

I've opted not to split it out as a separate build var to reduce the number of separate builds. This is essentially another form of sophisticated listing, hence putting it there.